### PR TITLE
Fix poll payment contract

### DIFF
--- a/swaggerpay/payswaggerlatest.json
+++ b/swaggerpay/payswaggerlatest.json
@@ -117,7 +117,7 @@
         }
       }
     },
-    "/ExternalTransaction/Poll/{callerTransactionId}": {
+    "/ExternalTransaction/Poll": {
       "get": {
         "tags": [
           "ExternalTransaction"
@@ -127,7 +127,7 @@
         "parameters": [
           {
             "name": "callerTransactionId",
-            "in": "path",
+            "in": "query",
             "required": true,
             "type": "string",
             "format": "uuid",


### PR DESCRIPTION
The callerTransactionId is to be requested as a part of poll payment query param and not path.