### PR TITLE
fix refund provider response field nullable value

### DIFF
--- a/swaggerpay/payswaggerlatest.json
+++ b/swaggerpay/payswaggerlatest.json
@@ -3056,7 +3056,7 @@
           "providerReference": {
             "type": "string",
             "example": "8ac7a4a28749242d01874c7e648327b7",
-            "nullable": false
+            "nullable": true
           },
           "providerResponseCode": {
             "type": "string",


### PR DESCRIPTION
set the nullable to true for providerresponse of refund api in case of failure it would be false